### PR TITLE
Add docs on Sinphasé cost functions and hotwiring

### DIFF
--- a/docs/dynamic-static-cost-function.md
+++ b/docs/dynamic-static-cost-function.md
@@ -1,0 +1,27 @@
+# Sinphasé Dynamic vs Static Cost Functions
+
+This document summarizes how LibPolyCall applies cost analysis within the Sinphasé governance framework.
+
+## Dynamic Cost Function
+
+A dynamic cost function evaluates component cost based on real-time metrics collected from the code base. In LibPolyCall this is implemented by `SinphaseCostCalculator` in `sinphase_governance/core/evaluator/cost_calculator.py`. Metrics such as lines of code, dependency count, and cyclomatic complexity are analyzed, then a weighted cost is calculated:
+
+```
+cost = (lines * lines_factor)
+      + (complexity * complexity_factor)
+      + (dependencies * dependency_factor)
+      + (functions * function_factor)
+```
+
+The weights are configurable and may change between phases. Because metrics are recomputed each run, the resulting cost adapts to code changes. This "model" style approach lets developers see the impact of refactoring or new features immediately.
+
+## Static Cost Function
+
+A static cost function uses pre‑determined values for each component. The calculation does not change at runtime. This approach is used when cost data must remain consistent across builds or when live analysis is too expensive.
+
+Static values can be derived from a previous dynamic analysis or from governance policy. Once recorded, they remain fixed until manually updated.
+
+## Hybrid Usage
+
+LibPolyCall's governance tooling allows either approach. During early development the dynamic calculation provides continuous feedback. As components stabilize, static values may be locked in to ensure repeatability and to support hotwiring of legacy features. Hotwiring lets developers gradually replace old API functions while keeping compatibility layers in place. Cost tracking helps ensure the new code remains within acceptable complexity thresholds.
+

--- a/docs/hotwiring-architecture/backward_compatibility.md
+++ b/docs/hotwiring-architecture/backward_compatibility.md
@@ -1,0 +1,13 @@
+# Hotwiring for Backward Compatibility
+
+Hotwiring in LibPolyCall allows developers to replace legacy API functionality without breaking existing integrations. By routing old command paths to new implementation modules, applications can gradually adopt updated features while remaining functional.
+
+## Approach
+
+1. **Compatibility Layer** – Provide thin wrappers around deprecated functions. These wrappers forward requests to new modules using the Sinphasé command interface.
+2. **Incremental Replacement** – Update one feature at a time. Each replacement includes cost analysis to confirm that the new code stays within acceptable complexity thresholds.
+3. **Telemetry Hooks** – Maintain telemetry in both old and new code paths to verify behaviour and gather usage statistics.
+4. **Isolation Triggers** – If a new module exceeds the configured cost threshold, it can be isolated into a separate component until optimised.
+
+This strategy ensures stable evolution of the runtime while following the single-pass, hierarchical structuring pattern promoted by the Sinphasé framework.
+


### PR DESCRIPTION
## Summary
- document dynamic vs static cost functions
- explain backward compatibility strategy for hotwiring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ebcfd950083278c48db749cf81d76