### PR TITLE
Add adapter integration and multi-agent docs

### DIFF
--- a/docs/code_ai_4agent_framework.md
+++ b/docs/code_ai_4agent_framework.md
@@ -1,0 +1,35 @@
+# Code AI 4-Agent Task Distribution Framework
+
+This reference outlines the collaborative workflow used when developing LibPolyCall with multiple AI agents. The framework organizes work into four specialized roles so that core features, language bindings, and testing proceed in parallel.
+
+## Agent Roles
+
+1. **Core Developer**
+   - Implements the topology manager and thread registration logic.
+   - Builds the validation engine and trace emission system.
+   - Ensures all C interfaces remain stable for language bindings.
+
+2. **API Developer & Integration Specialist**
+   - Creates language bindings for Python, Node.js, and Go.
+   - Designs the public API functions and configuration parsers.
+   - Adds daemon support with optional `--detach` mode.
+
+3. **QA Engineer & Unit Test Developer**
+   - Maintains the unit test suite with a coverage target above 90%.
+   - Implements stress tests for thread safety and performance benchmarks.
+   - Runs security audits on new code before merge.
+
+4. **QA Analyst & Documentation Specialist**
+   - Performs end‑to‑end integration testing across language bindings.
+   - Writes API reference material and troubleshooting guides.
+   - Generates coverage and performance reports for each release.
+
+## Workflow Phases
+
+1. **Core Infrastructure** – Core developer and API specialist implement the topology manager and base APIs.
+2. **Testing Framework** – QA engineer and documentation specialist create unit and integration tests.
+3. **Language Bindings** – All agents collaborate to ensure bindings function consistently.
+4. **Documentation & Validation** – Testing and documentation finalize the release, ensuring quality gates are met.
+
+Each phase ends with a review where agents verify code quality, coverage metrics, and documentation completeness before proceeding.
+

--- a/docs/hotwiring-architecture/README.md
+++ b/docs/hotwiring-architecture/README.md
@@ -141,3 +141,8 @@ Hot-wiring architecture embodies "Computing from the Heart" philosophy through:
 **OBINexus Computing**: Hot-wiring architecture represents systematic compassion encoded in protocol, ensuring technology serves human outcomes while maintaining technical excellence.
 
 *Computing from the Heart. Building with Purpose. Running with Heart.*
+For adapter integration details see [hotwiring_adapter_integration_spec.md](./hotwiring_adapter_integration_spec.md).
+
+
+The multi-agent development workflow is described in [../code_ai_4agent_framework.md](../code_ai_4agent_framework.md).
+

--- a/docs/hotwiring-architecture/hotwiring_adapter_integration_spec.md
+++ b/docs/hotwiring-architecture/hotwiring_adapter_integration_spec.md
@@ -1,0 +1,47 @@
+# Hotwiring Adapter Integration Specification
+
+This document summarizes the core adapter interface design and multi-language integration strategy for LibPolyCall. The goal is to provide a unified, thread-safe adapter layer that supports Python, Go, and Node.js bindings while maintaining consistent lifecycle management across the C runtime.
+
+## Core Adapter Interface
+
+The base adapter structure defines function pointers for initialization, layer transitions, trace emission, and cleanup. Each adapter maintains a reference to the global topology manager and uses an atomic reference counter for memory safety.
+
+Key fields:
+- `vtable` – language-specific implementations of the adapter operations
+- `manager` – pointer to the shared topology manager
+- `ref_count` – atomic reference counter for lifecycle management
+- `mutex` – mutex protecting adapter state
+- `language_specific_data` – pointer reserved for binding data
+- `adapter_layer_id` – numeric identifier for the adapter
+
+Thread-safe transitions are performed through `adapter_execute_transition`, which validates layer changes and updates thread context.
+
+## Language-Specific Implementations
+
+### Python CFFI Adapter
+- Acquires the Python GIL before executing a transition
+- Stores callbacks in a `PyDict` for dispatch
+- Sets `adapter_layer_id` to the Python layer constant
+
+### Go CGO Adapter
+- Ensures transitions occur on the originating OS thread
+- Notifies the Go runtime of successful transitions via CGO callbacks
+- Stores a `go_handle` used by exported Go functions
+
+### Node.js N-API Adapter
+- Uses `napi_env` and `uv_async_t` for event-loop safe transitions
+- Opens and closes handle scopes around calls into the Node.js runtime
+- Queues asynchronous notifications on successful layer entry
+
+## Adapter Registry
+
+Adapters are stored in a registry indexed by layer ID. A read–write lock guards registry access so that multiple threads can look up adapters concurrently while registration occurs under a write lock.
+
+## Transition Orchestration
+
+The orchestrator coordinates transitions between adapters. It first exits the current layer using the source adapter and then enters the target layer using the destination adapter. Errors in either step abort the transition and propagate back to the caller.
+
+## Testing and Performance
+
+Unit tests exercise thread safety by spawning multiple threads that perform rapid transitions. Integration tests verify that a Python layer can safely transition into a Go layer and back again. Transition validation and trace emission are benchmarked to ensure targets of less than 100µs per transition.
+


### PR DESCRIPTION
## Summary
- document adapter integration approach
- outline multi-agent development framework
- reference the new docs from the hotwiring architecture README

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6862aab1eb2c83278c25dcdd1b7b4274